### PR TITLE
Adding argument to supply a 'from_email' argument as its now required by the PagerDuty's API.

### DIFF
--- a/pagerduty_plugin.py
+++ b/pagerduty_plugin.py
@@ -15,6 +15,7 @@ class PagerDutyIncidentOperator(BaseOperator):
     @apply_defaults
     def __init__(self,
                  api_key=None,
+                 from_email=None,
                  title='unset',
                  service_id='No service id has been set',
                  details='No details have been set',
@@ -25,9 +26,16 @@ class PagerDutyIncidentOperator(BaseOperator):
         self.title = title
         self.service_id = service_id
         self.details = details
+        self.from_email = from_email
 
     def execute(self, **kwargs):
         pypd.api_key = self.api_key
+
+        headers = None
+        if self.from_email:
+            headers = {
+                'From': self.from_email
+            }
 
         try:
             r = pypd.Incident.create(data={
@@ -41,7 +49,7 @@ class PagerDutyIncidentOperator(BaseOperator):
                     'type': 'incident_body',
                     'details': self.details,
                 }
-            })
+            }, add_headers=headers)
             logging.info(r)
         except Exception as ex:
             msg = "PagerDuty API call failed ({})".format(ex)


### PR DESCRIPTION
Fixes #1 

I included the argument 'from_email' that is now required by the PagerDuty's API.  It's not mandatory and will not be included if not supplied.